### PR TITLE
ci: route linux x64 jobs to self-hosted podman fleet

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   test:
     name: Test Suite
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, podman]
     strategy:
       matrix:
         rust: [stable, nightly]
@@ -55,7 +55,7 @@ jobs:
 
   clippy:
     name: Clippy
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, podman]
     steps:
       - uses: actions/checkout@v6
       
@@ -69,7 +69,7 @@ jobs:
 
   fmt:
     name: Rustfmt
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, podman]
     steps:
       - uses: actions/checkout@v6
       
@@ -83,7 +83,7 @@ jobs:
 
   build:
     name: Build
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, podman]
     steps:
       - uses: actions/checkout@v6
       
@@ -104,7 +104,7 @@ jobs:
 
   docs:
     name: Documentation
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, podman]
     steps:
       - uses: actions/checkout@v6
       


### PR DESCRIPTION
## Summary
Adapts GitHub Actions for the shared **gha-runner-ctl** WSL fleet.

## Changes
- `runs-on: [self-hosted, linux, x64, podman]` for linux x64 jobs
- Matrix/release linux legs mapped to fleet labels; macOS/Windows/ARM64 unchanged
- Push/PR triggers added on primary CI workflows that were manual-only

## Fleet labels
CPU: `[self-hosted, linux, x64, podman]` · GPU (occasional): add `gpu` label