### PR TITLE
fix(build): restore workspace.dependencies for CubeCL 0.9 pins

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,3 +44,17 @@ pedantic = "warn"
 [[bench]]
 name = "kernels"
 harness = false
+
+[workspace]
+members = ["."]
+resolver = "2"
+
+[workspace.dependencies]
+candle-core = "0.9"
+candle-nn = "0.9"
+thiserror = "2.0"
+tracing = "0.1"
+cubecl = "0.9"
+cubecl-cuda = "0.9"
+criterion = "0.8"
+anyhow = "1.0"


### PR DESCRIPTION
## Summary
Post-promote verification failed at manifest parse:
```
error inheriting `candle-core` from workspace root manifest's `workspace.dependencies.candle-core`
failed to find a workspace root
```

CubeCL 0.9 migration switched deps to `{ workspace = true }` without adding a `[workspace]` table.

## Fix
Restore workspace root with candle/cubecl **0.9** pins aligned to the CubeCL 0.9 migration.

## Verification
- `cargo check` → **PASS**
- lib unit tests → **PASS** (128)
- `cargo test` integration: **2 FAIL** (pre-existing numerical accuracy on Flash Attention CPU fallback — not addressed here; MAE ~0.73 vs 1e-6 target)

## Out of scope
Flash Attention CPU fallback accuracy (`tests/gpu/flash_attention.rs`) needs a separate algorithmic fix, not a manifest tweak.