### PR TITLE
fix(test): flash-attn reference scale + DEBT.md (P8 residual)

### DIFF
--- a/DEBT.md
+++ b/DEBT.md
@@ -1,0 +1,35 @@
+# Technical debt — unsloth-rs
+
+## Flash attention residual (P8 / W1 train track)
+
+**Last updated:** 2026-07-16  
+**Evidence:** `/root/work/plans/evidence/48h/L1-F-unsloth/`, `/root/work/plans/evidence/P8-residuals/`
+
+### Resolved (test reference)
+
+- **Integration reference scaling:** `tests/gpu/flash_attention.rs` `attention_reference_cpu` used `scores / scale` while the CubeCL fallback and `kernels/cubecl/kernel.rs` `reference_attention` use `scores * scale` with `scale = 1/√head_dim`. That mismatch caused false failures on `test_flash_attention_cpu_fallback_accuracy` / `test_flash_attention_gpu_integration` (MAE ~0.73). Fixed in PR branch `fix/flash-attn-reference-scale` (multiply, not divide).
+
+### Open — environment / GPU gate
+
+| Item | Status | Notes |
+|------|--------|-------|
+| `test_flash_attention_gpu_numerical_equivalence` | **Not run** | Requires CUDA device + `cuda` feature |
+| `cargo test --features cuda --test integration` | **Blocked** | Past evidence: missing `use candle_core::IndexOp` at `tests/gpu/flash_attention.rs` (~768) when `cuda` enabled |
+| Host GPU runtime | **BLOCKED:env** | Evidence: missing `/dev/nvidia0`, `CUDA_ERROR_NO_DEVICE`; Blackwell CC 12.0 needs `CUDA_COMPUTE_CAP=90` for nvcc 12.0 candle-kernels build |
+| `./scripts/gpu-test.sh` full validate | **BLOCKED:env** | Documented in L1-F `env-snapshot.log` |
+
+### Open — product / algorithm (not in P8 scope)
+
+- Ternary attention paths still use `/ scale` in some modules (`src/kernels/attention.rs`, `ternary/attention.rs`) — separate from flash-attn integration reference; audit if tests expand.
+- Consumer train story (axolotl-rs E2E) remains downstream of honest GPU numerical evidence.
+
+### Verification commands
+
+```bash
+# CPU default (post reference-scale fix)
+cargo test --workspace --no-default-features
+cargo test --test integration test_flash_attention
+
+# GPU (when env healthy)
+CUDA_COMPUTE_CAP=90 cargo test --features cuda --test integration test_flash_attention_gpu_numerical_equivalence -- --nocapture
+```

--- a/tests/gpu/flash_attention.rs
+++ b/tests/gpu/flash_attention.rs
@@ -150,7 +150,7 @@ fn attention_reference_cpu(
 ) -> Result<Tensor> {
     // Compute Q·K^T
     let scores = q.matmul(&k.transpose(2, 3)?.contiguous()?)?;
-    let scores = (scores / scale)?;
+    let scores = (scores * scale)?;
 
     // Apply mask if provided
     let scores = match mask {


### PR DESCRIPTION
## Summary

- Fix `attention_reference_cpu` to use `scores * scale` (matches CubeCL fallback / lib `reference_attention`)
- Add `DEBT.md` documenting remaining **BLOCKED:env** GPU gates and cuda integration compile debt

## Verify

```bash
cargo test --workspace --no-default-features
cargo test --test integration test_flash_attention
```

P8 evidence: workspace plans `P8-residuals/` + L1-F flash-attn report.

No algorithm/kernel changes.