### PR TITLE
docs: DEPENDENCIES + README docs index for 1.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Documentation
+- Added `docs/DEPENDENCIES.md` (foundation kernels; no peft/qlora/axolotl deps; no cycles).
+- README docs index: CHANGELOG, ROADMAP, DEBT, GPU_SETUP, PUBLISHING, DEPENDENCIES.
+
 ## [1.0.3] - 2026-07-22
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -67,9 +67,12 @@ still incomplete.
 - Ternary CubeCL GPU kernels (archived under `archive/ternary_cubecl/`)
 - CubeCL f16/bf16 kernels in 1.0.x (explicit f32-only interop scope)
 
-See [DEBT.md](DEBT.md) and [GPU_SETUP.md](GPU_SETUP.md) for residual risk and
-CUDA environment contract (`CUDA_COMPUTE_CAP`, `FAIL_ENV` classification).
+**Docs:** [CHANGELOG.md](CHANGELOG.md) · [ROADMAP.md](ROADMAP.md) · [DEBT.md](DEBT.md) ·
+[GPU_SETUP.md](GPU_SETUP.md) · [PUBLISHING.md](PUBLISHING.md) ·
+[docs/DEPENDENCIES.md](docs/DEPENDENCIES.md) (no peft/qlora/axolotl deps; no cycles).
 
+Residual risk and CUDA environment contract (`CUDA_COMPUTE_CAP`, `FAIL_ENV`) are in
+[DEBT.md](DEBT.md) and [GPU_SETUP.md](GPU_SETUP.md).
 ## Installation
 
 ```toml

--- a/docs/DEPENDENCIES.md
+++ b/docs/DEPENDENCIES.md
@@ -1,0 +1,36 @@
+# unsloth-rs dependency graph
+
+## DAG (no cycles)
+
+```text
+candle-core, candle-nn, cubecl (optional feature), …
+              │
+              ▼
+         ┌──────────┐
+         │unsloth-rs│  ← foundation kernels; NO peft/qlora/axolotl deps
+         └────┬─────┘
+              │ optional consumer
+              ▼
+         axolotl-rs (feature unsloth)
+```
+
+**unsloth-rs must never depend on peft-rs, qlora-rs, or axolotl-rs.**
+Compose PEFT training via those crates, not this one.
+
+## Features
+
+| Feature | Effect |
+|---------|--------|
+| *(default)* | CPU Candle kernels |
+| `cuda` | CubeCL + candle CUDA paths; see [GPU_SETUP.md](../GPU_SETUP.md) |
+
+## Runtime notes (docs, not deps)
+
+- Pin `CUDA_COMPUTE_CAP=90` when host reports CC 12.0 but nvcc max is 9.0  
+- WSL: prefer `LD_LIBRARY_PATH=/usr/lib/wsl/lib` for a real `libcuda`  
+- Host D2H/H2D interop is a permanent limitation with public Candle 0.9 / CubeCL 0.9 APIs  
+
+## Package surface
+
+`archive/` (ternary CubeCL drafts) is **excluded** from the crates.io package.
+Only `ROADMAP.md` (not a lowercase duplicate) ships for packaging safety.


### PR DESCRIPTION
## Summary
Docs-only refresh so **no crate ships without accurate, updated documentation**.

- README docs index + honest capability claims
- `docs/DEPENDENCIES.md` (DAG, no circular deps, pin/publish rules)
- Stale trackers (TASK_TRACKER / GAP_ANALYSIS / STATUS) aligned with current version
- axolotl: remove false committed path-dep claims; document `use-local-path-deps.sh`

## Test plan
- [x] Docs-only (no product code required)
- [ ] Quick `cargo test --lib` still green if CI runs