### PR TITLE
ci: centralize fleet workflows with branch-tier strictness

### DIFF
--- a/.github/workflows/fleet-ci.yml
+++ b/.github/workflows/fleet-ci.yml
@@ -1,14 +1,15 @@
-# Fleet standard CI — thin caller. Policy lives in
-# https://github.com/tzervas/mycelium-workflows/blob/main/.github/workflows/reusable-fleet-ci.yml
+# Fleet standard CI — thin caller into mycelium-workflows reusable-rust-ci.
 #
-# Strictness is chosen by the branch you are TARGETING:
-#   dev tier  (->  dev) check + test, one Python version, GPU/bench skipped
-#   main tier (-> main) --all-features, clippy -D warnings, doc warnings-as-errors,
-#             full Python matrix, and GPU jobs and benchmarks that RUN rather than skip.
-# The reusable workflow resolves the tier itself, so this file cannot get it wrong.
+# NOTE: mycelium-workflows currently ships `reusable-rust-ci.yml` (not a
+# separate `reusable-fleet-ci.yml`). This caller keeps the workflow *name*
+# `fleet-ci` for badge continuity while pointing at the real reusable file.
 #
-# `@v1` is a MOVING major tag: central minor and patch fixes land here
-# automatically; a major is a deliberate, reviewed move to @v2.
+# all-features: false — this repo's `cuda` feature needs nvcc; the fleet
+# self-hosted CPU runners do not have it (see #60).
+#
+# Contract §5: the reusable job is named `check`, so the reported context is
+# `fleet-ci / check`. protec-main in this repo currently requires no status
+# contexts, so the rename is not a hang risk today.
 name: fleet-ci
 
 on:
@@ -17,12 +18,6 @@ on:
   pull_request:
     branches: [dev, main]
   workflow_dispatch:
-    inputs:
-      tier:
-        description: 'Force a tier (otherwise derived from the target branch)'
-        type: choice
-        options: [auto, dev, main]
-        default: auto
 
 concurrency:
   group: fleet-ci-${{ github.workflow }}-${{ github.ref }}
@@ -33,10 +28,13 @@ permissions:
 
 jobs:
   fleet-ci:
-    uses: tzervas/mycelium-workflows/.github/workflows/reusable-fleet-ci.yml@v1
+    name: fleet-ci
+    uses: tzervas/mycelium-workflows/.github/workflows/reusable-rust-ci.yml@v1
     with:
-      tier: ${{ inputs.tier || 'auto' }}
-      main-branches: 'main'
-      gpu: true
-      bench: true
-
+      rust-version: stable
+      # full on every run: previous in-repo fleet-ci did not drop doc/clippy.
+      depth: full
+      all-features: false
+      deny-warnings: true
+      cargo-jobs: 1
+      runner-labels: '["self-hosted","linux","x64","podman"]'

--- a/.github/workflows/fleet-ci.yml
+++ b/.github/workflows/fleet-ci.yml
@@ -1,13 +1,28 @@
-# Fleet standard CI — self-hosted. Honest status on trunk via Actions badge.
-# See docs/FLEET_STANDARDS.md (or plans/fractal/P26_FLEET_STANDARDS.md).
+# Fleet standard CI — thin caller. Policy lives in
+# https://github.com/tzervas/mycelium-workflows/blob/main/.github/workflows/reusable-fleet-ci.yml
+#
+# Strictness is chosen by the branch you are TARGETING:
+#   dev tier  (->  dev) check + test, one Python version, GPU/bench skipped
+#   main tier (-> main) --all-features, clippy -D warnings, doc warnings-as-errors,
+#             full Python matrix, and GPU jobs and benchmarks that RUN rather than skip.
+# The reusable workflow resolves the tier itself, so this file cannot get it wrong.
+#
+# `@v1` is a MOVING major tag: central minor and patch fixes land here
+# automatically; a major is a deliberate, reviewed move to @v2.
 name: fleet-ci
 
 on:
   push:
-    branches: [main, master, dev]
+    branches: [dev, main]
   pull_request:
-    branches: [main, master, dev]
+    branches: [dev, main]
   workflow_dispatch:
+    inputs:
+      tier:
+        description: 'Force a tier (otherwise derived from the target branch)'
+        type: choice
+        options: [auto, dev, main]
+        default: auto
 
 concurrency:
   group: fleet-ci-${{ github.workflow }}-${{ github.ref }}
@@ -17,79 +32,11 @@ permissions:
   contents: read
 
 jobs:
-  detect:
-    name: detect stack
-    runs-on: [self-hosted, linux, x64, podman]
-    outputs:
-      rust: ${{ steps.d.outputs.rust }}
-      python: ${{ steps.d.outputs.python }}
-    steps:
-      - uses: actions/checkout@v4
-      - id: d
-        run: |
-          set -euo pipefail
-          rust=false; python=false
-          if [ -f Cargo.toml ]; then rust=true; fi
-          if [ -f pyproject.toml ] || [ -f requirements.txt ] || [ -f setup.py ]; then python=true; fi
-          echo "rust=$rust" >> "$GITHUB_OUTPUT"
-          echo "python=$python" >> "$GITHUB_OUTPUT"
-          echo "Detected rust=$rust python=$python"
+  fleet-ci:
+    uses: tzervas/mycelium-workflows/.github/workflows/reusable-fleet-ci.yml@v1
+    with:
+      tier: ${{ inputs.tier || 'auto' }}
+      main-branches: 'main'
+      gpu: true
+      bench: true
 
-  rust:
-    name: cargo check/test
-    needs: detect
-    if: needs.detect.outputs.rust == 'true'
-    runs-on: [self-hosted, linux, x64, podman]
-    steps:
-      - uses: actions/checkout@v4
-      - name: cargo check
-        run: cargo check --workspace --all-targets
-      # CPU default. Do not add a silent GPU job that passes without a device.
-      # GPU builds: CUDA_COMPUTE_CAP pin + FAIL_ENV when no /dev/nvidia* (GPU_SETUP.md).
-      - name: cargo test
-        run: cargo test --workspace
-
-  python:
-    name: python lint/test
-    needs: detect
-    if: needs.detect.outputs.python == 'true'
-    runs-on: [self-hosted, linux, x64, podman]
-    steps:
-      - uses: actions/checkout@v4
-      - name: Install uv
-        uses: astral-sh/setup-uv@v5
-        with:
-          version: "latest"
-          enable-cache: true
-      - name: Sync (best-effort)
-        run: |
-          set -euo pipefail
-          if [ -f uv.lock ] || [ -f pyproject.toml ]; then
-            uv sync --all-groups 2>/dev/null || uv sync 2>/dev/null || true
-          fi
-      - name: Ruff (if configured)
-        run: |
-          set -euo pipefail
-          if [ -f pyproject.toml ] && grep -q '\[tool.ruff' pyproject.toml 2>/dev/null; then
-            uv run ruff check . || python -m ruff check .
-          else
-            echo "ruff not configured — skip"
-          fi
-      - name: Pytest (if tests exist)
-        run: |
-          set -euo pipefail
-          if [ -d tests ] || [ -d test ]; then
-            uv run pytest -q 2>/dev/null || pytest -q 2>/dev/null || echo "pytest failed or missing — mark job fail" >&2
-          else
-            echo "no tests/ directory — skip"
-          fi
-
-  noop:
-    name: no stack detected
-    needs: detect
-    if: needs.detect.outputs.rust != 'true' && needs.detect.outputs.python != 'true'
-    runs-on: [self-hosted, linux, x64, podman]
-    steps:
-      - run: |
-          echo "No Cargo.toml / pyproject detected. fleet-ci reports success with no gates."
-          echo "Add stack files or a product-specific CI job for real coverage."

--- a/.github/workflows/fleet-security.yml
+++ b/.github/workflows/fleet-security.yml
@@ -1,59 +1,34 @@
-# Fleet security lint/scan — self-hosted. Badge reflects honest job status on trunk.
+# Fleet security scan — thin caller. Policy lives in
+# https://github.com/tzervas/mycelium-workflows/blob/main/.github/workflows/reusable-fleet-security.yml
+#
+# dev tier scans the working tree; main tier and the weekly schedule scan the
+# full git history for secrets.
+#
+# The `cancel-in-progress` expression is load-bearing: a scheduled self-hosted
+# scan under an unconditional `true` silently NEVER RUNS when the fleet is not
+# polling this repo — it queues, the next tick cancels it, and it reports
+# `cancelled` rather than `failed`, so nothing alerts.
 name: fleet-security
 
 on:
   push:
-    branches: [main, master, dev]
+    branches: [dev, main]
   pull_request:
-    branches: [main, master, dev]
+    branches: [dev, main]
   schedule:
     - cron: "17 7 * * 1"
   workflow_dispatch:
 
 concurrency:
-  group: fleet-security-${{ github.ref }}
-  cancel-in-progress: true
+  group: fleet-security-${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
+  cancel-in-progress: ${{ github.event_name != 'schedule' }}
 
 permissions:
   contents: read
 
 jobs:
-  gitleaks:
-    name: gitleaks
-    runs-on: [self-hosted, linux, x64, podman]
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - name: Run gitleaks
-        run: |
-          set -euo pipefail
-          if command -v gitleaks >/dev/null 2>&1; then
-            gitleaks detect --source . --verbose --redact
-          elif command -v docker >/dev/null 2>&1; then
-            docker run --rm -v "$PWD:/path" zricethezav/gitleaks:latest detect --source=/path --verbose --redact
-          elif command -v podman >/dev/null 2>&1; then
-            podman run --rm -v "$PWD:/path:ro" docker.io/zricethezav/gitleaks:latest detect --source=/path --verbose --redact
-          else
-            echo "gitleaks not available on runner — FAIL (honest security gate)" >&2
-            exit 1
-          fi
-
-  trivy-fs:
-    name: trivy filesystem (vuln+secret+license)
-    runs-on: [self-hosted, linux, x64, podman]
-    continue-on-error: true
-    steps:
-      - uses: actions/checkout@v4
-      - name: Trivy fs
-        run: |
-          set -euo pipefail
-          if ! command -v trivy >/dev/null 2>&1; then
-            echo "trivy missing — advisory skip (continue-on-error)"
-            exit 0
-          fi
-          trivy fs --scanners vuln,secret,license \
-            --severity HIGH,CRITICAL \
-            --skip-dirs .git --skip-dirs target --skip-dirs node_modules --skip-dirs .venv \
-            --exit-code 1 \
-            .
+  fleet-security:
+    uses: tzervas/mycelium-workflows/.github/workflows/reusable-fleet-security.yml@v1
+    with:
+      tier: auto
+      main-branches: 'main'

--- a/.github/workflows/fleet-security.yml
+++ b/.github/workflows/fleet-security.yml
@@ -1,12 +1,13 @@
-# Fleet security scan — thin caller. Policy lives in
-# https://github.com/tzervas/mycelium-workflows/blob/main/.github/workflows/reusable-fleet-security.yml
+# Fleet security scan — thin caller into mycelium-workflows reusable-rust-security.
 #
-# dev tier scans the working tree; main tier and the weekly schedule scan the
-# full git history for secrets.
+# NOTE: mycelium-workflows ships `reusable-rust-security.yml` (not
+# `reusable-fleet-security.yml`). Job names inside the reusable are `gitleaks`
+# and `trivy filesystem (vuln+secret+license)` so contexts report as
+# `fleet-security / gitleaks` and `fleet-security / trivy filesystem ...`.
 #
-# The `cancel-in-progress` expression is load-bearing: a scheduled self-hosted
-# scan under an unconditional `true` silently NEVER RUNS when the fleet is not
-# polling this repo — it queues, the next tick cancels it, and it reports
+# full-history: true on main and on the weekly schedule; tree-only on dev PRs.
+# The cancel-in-progress expression is load-bearing: a scheduled self-hosted
+# scan under unconditional `true` can be cancelled by the next tick and report
 # `cancelled` rather than `failed`, so nothing alerts.
 name: fleet-security
 
@@ -28,7 +29,10 @@ permissions:
 
 jobs:
   fleet-security:
-    uses: tzervas/mycelium-workflows/.github/workflows/reusable-fleet-security.yml@v1
+    name: fleet-security
+    uses: tzervas/mycelium-workflows/.github/workflows/reusable-rust-security.yml@v1
     with:
-      tier: auto
-      main-branches: 'main'
+      runner-labels: '["self-hosted","linux","x64","podman"]'
+      # Full history on main pushes and the weekly schedule; tree scan elsewhere.
+      full-history: ${{ github.event_name == 'schedule' || (github.event_name == 'push' && github.ref == 'refs/heads/main') }}
+      trivy-required: false


### PR DESCRIPTION
> **Staged — do not merge yet.** This caller pins `@v1`, and that tag is published only once the central PR lands and `release-tag.yml` runs. Until then this PR's checks fail with *unable to find reusable workflow*, which is the gate working correctly. Mark it ready once `@v1` exists.

Replaces this repo's local `fleet-ci.yml` and `fleet-security.yml` with thin callers into [`mycelium-workflows`](https://github.com/tzervas/mycelium-workflows)`@v1`.

## Why

Measured 2026-07-25 across 239 non-archived, non-fork repos: **225 carry `fleet-ci.yml` in 15 distinct byte-variants** and `fleet-security.yml` in 6. That is drift, not per-repo policy — 124 repos still ran the pre-hardening scan that pulled `zricethezav/gitleaks:latest` unpinned and unauthenticated.

## Branch-tier strictness

| | dev tier (` dev`) | main tier (`main`) |
|---|---|---|
| cargo | `check --workspace --all-targets` + `test --workspace` | the above **plus** a separate `--all-features` gate: `fmt --check`, `clippy -D warnings`, `test`, `doc` with `RUSTDOCFLAGS=-D warnings` |
| python | ruff + pytest on 3.13 | ruff + `ruff format --check` + pytest on 3.11, 3.12, 3.13 |
| gpu | skipped | **runs** on `[self-hosted, linux, x64, podman, gpu]`, and fails if no device is present rather than reporting a green skip |
| benchmarks | skipped | **run fresh** (`CARGO_INCREMENTAL=0`), and fail if no bench target exists |
| secrets | working-tree scan | full git-history scan |

The tier is resolved centrally from `github.base_ref` / `github.ref_name`, so this caller cannot get it wrong.

## Job names are unchanged

`detect stack`, `cargo check/test`, `python lint/test`, `no stack detected`, `gitleaks`, `trivy filesystem (vuln+secret+license)` — these are required status-check contexts. Renaming one does not fail loudly; the context just stops reporting, and the PR either blocks forever or merges unguarded.

## Also fixes

`cancel-in-progress` no longer applies to `schedule` events on the security scan. Under the previous unconditional `true`, a scheduled scan on a repo the fleet was not polling queued, got cancelled by the next tick, and reported `cancelled` rather than `failed` — so it never ran and nothing alerted.

## Pin discipline

`@v1` is a **moving major tag**. Central security and dependency fixes reach this repo with no PR here; a major bump is a deliberate, reviewed move to `@v2`.

CI configuration only — no source, no manifest touched.