### PR TITLE
release: 1.0.3 (blocked on consolidated PR merges into dev)

### DIFF
--- a/.cz.toml
+++ b/.cz.toml
@@ -1,0 +1,24 @@
+# Commitizen configuration (commitizen-tools).
+# Install (optional): pip install commitizen  OR  uv tool install commitizen
+# This file is valid without the CLI: agents and humans follow conventional-commit
+# rules for the same bumps.
+#
+# GRANDFATHERED 1.x: this crate is already published on crates.io at 1.x.
+# major_version_zero must be false (unlike 0.x fleet defaults).
+
+[tool.commitizen]
+name = "cz_conventional_commits"
+version = "1.0.3"
+tag_format = "v$version"
+version_scheme = "semver"
+major_version_zero = false
+
+# Only list paths that exist in this repo and actually carry the package version.
+version_files = [
+    "Cargo.toml:version",
+]
+
+update_changelog_on_bump = true
+changelog_file = "CHANGELOG.md"
+changelog_incremental = true
+# cz bump: prefer `cz bump --increment PATCH|MINOR|MAJOR` after human review.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,45 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+> **Release-PR note:** entries below describe work that lives on open PRs into `dev`.
+> They are **not** on `dev`/`main` until an operator merges the listed prerequisites.
+> This section is the planned 1.0.3 publication narrative (version already in
+> `Cargo.toml`; crates.io still at 1.0.2 — do not double-bump).
+
+### Prerequisites (operator merge into `dev`, then re-cut this release PR if needed)
+- #59 — quality: `RmsNorm::vram_estimate`, SwiGLU estimate test, rustdoc ports, fleet-ci OOM pin
+- #60 — CI: stop `--all-features`/CUDA on CPU runners; gitleaks allowlist; reopen-issues YAML; rustdoc
+- #61 — CI: fleet-ci / fleet-security callers fixed to real mycelium-workflows reusables
+- #62 — CI: product `CI` workflow calls `reusable-rust-ci` with `all-features: false`
+- #57 — optional / **not recommended until protec-main requires real checks** (Jules automerge)
+
+### Added
+- `RmsNorm::vram_estimate(batch, seq)` for activation-scratch planning (parity with Attention/SwiGLU) — #59
+- Unit tests for RmsNorm and SwiGLU VRAM estimates — #59
+
+### Fixed
+- CI on CPU-only self-hosted runners no longer passes `--all-features` (which pulled `cuda` → cudarc → `nvcc` hard-fail) — #60
+- Gitleaks config: rule allowlists are TOML tables (`[rules.allowlist]`), not arrays of tables — #60
+- `reopen-issues-closed-off-main` Python heredoc indent so YAML `|` blocks parse (startup_failure) — #60
+- Rustdoc / intra-doc links: shape brackets, `CalibrationMethodConfig`, `mod@fused_rmsnorm_rope`, `` `Vec<u32>` ``, `CheckpointConfig` — #59 / #60
+- Centralized CI callers reference workflows that actually exist in `mycelium-workflows` — #61
+- Centralized product CI does not reintroduce CUDA-on-CPU via `all-features: true` — #62
+- Jules automerge refuses merge when zero successful checks exist (empty list was a silent pass) — #57
+
+### Changed
+- Fleet CI / security workflows become thin callers of `tzervas/mycelium-workflows` reusables — #61 / #62
+- Documented check-context renames under reusable callers (`Test Suite / check`, `fleet-ci / check`, …) — #61 / #62
+- `CARGO_BUILD_JOBS=1` on constrained self-hosted jobs to reduce OOM pressure — #59 / #60
+
 ### Documentation
 - Added `docs/DEPENDENCIES.md` (foundation kernels; no peft/qlora/axolotl deps; no cycles).
 - README docs index: CHANGELOG, ROADMAP, DEBT, GPU_SETUP, PUBLISHING, DEPENDENCIES.
+- Added `.cz.toml` for commitizen (grandfathered 1.x, `major_version_zero = false`).
+
+### Version reconciliation
+- **crates.io published:** 1.0.2 (broken tarball: case collision).
+- **Repo `Cargo.toml`:** already **1.0.3** (prior honesty/packaging bump, not yet published).
+- **Decision:** keep **1.0.3**. No further bump. Consolidated work is patch-level (CI correctness, docs, small estimate API + tests). Not a minor feature cut; not a major.
 
 ## [1.0.3] - 2026-07-22
 


### PR DESCRIPTION
## BLOCKED — do not merge yet

This draft release PR is **BLOCKED pending operator merge of the consolidated work PRs into `dev`**.

It intentionally contains **only** release-scoped artifacts (`.cz.toml`, CHANGELOG planning notes). It does **not** claim that the consolidated code is already on `dev` or `main`.

### Prerequisites (merge into `dev` first)

| PR | Role | Notes |
|----|------|-------|
| **#59** | Maintenance/quality **survivor** | `RmsNorm::vram_estimate`, SwiGLU tests, rustdoc ports, fleet-ci OOM pin. Closed dups: #50–#54. |
| **#60** | CI CPU/CUDA + gitleaks + reopen | Stop `--all-features` on CPU runners; real breakage fix. Supersedes #58. |
| **#61** | Fleet workflow centralization | Patched to call **real** mycelium-workflows files. |
| **#62** | Product CI → reusable-rust-ci | Patched: `all-features: false`, drop invalid `bench` input. |
| **#57** | Jules automerge (optional) | **Not recommended** until protec-main requires real status checks. Patched empty-check hole. |

Closed as duplicates/superseded: **#50, #51, #52, #53, #54, #58**.

### Version reconciliation

| Source | Version |
|--------|---------|
| crates.io | **1.0.2** (broken unpack: case collision) |
| `Cargo.toml` on main/dev | **1.0.3** (already bumped, never published) |

**No further bump.** 1.0.3 correctly describes a patch-level honesty/packaging + CI/docs/quality set. Double-bumping to 1.0.4 would misrepresent the unreleased state. Major stays 1 (grandfathered; human-only decision to cut 2.0).

### Release artifacts on this branch

- `.cz.toml` — `version_scheme = semver`, `tag_format = v$version`, **`major_version_zero = false`**, `version_files = ["Cargo.toml:version"]` (only path that exists and carries the package version).
- `CHANGELOG.md` `[Unreleased]` — derived from the consolidated PR conventional intents, with explicit prerequisite list.

### After prerequisites land

1. Fast-forward or recreate `release/1.0.3` from updated `dev`.
2. Confirm CHANGELOG `[1.0.3]` section matches what actually merged.
3. Mark this PR ready, wait for main-tier gates, operator merge to `main`.
4. Tag `v1.0.3` and publish to crates.io per `PUBLISHING.md`.

### Ruleset / automerge notes (for operators)

- `protec-main` requires **no** status check contexts today (0 approvals, block delete/non-FF only).
- Adopting reusable workflows renames contexts to `… / check` (§5). Safe today; if required checks are added later, use prefixed names.
- Do **not** enable #57 Jules automerge until required checks actually report.

### Verification already run on #59 survivor

```
cargo clippy --all-targets -- -D warnings   # ok
cargo test                                  # 134 lib + 39 integration + 3 doctest ok
RUSTDOCFLAGS=-D warnings cargo doc --no-deps  # ok
```

CUDA feature path: not required for this release-artifact PR; #59 default-feature verification is the code-side gate.