### PR TITLE
chore(version): add commitizen config and a versioning doc

### DIFF
--- a/.cz.toml
+++ b/.cz.toml
@@ -1,0 +1,48 @@
+# Commitizen configuration (commitizen-tools).
+# Install (optional): pip install commitizen  OR  uv tool install commitizen
+# This file is valid without the CLI: agents and humans follow docs/VERSIONING.md for the
+# same rules. Canonical peer reference: tzervas/gha-runner-ctl/.cz.toml
+#
+# ============================================================================
+# WHY `major_version_zero` IS DELIBERATELY ABSENT HERE
+# ============================================================================
+# The fleet standard sets `major_version_zero = true` everywhere, because nearly every
+# repo in the fleet is 0.x and that key is what keeps it there.
+#
+# THIS REPO IS AN EXCEPTION, AND THE KEY MUST NOT BE ADDED.
+#
+# `unsloth-rs` is PUBLISHED ON crates.io AT 1.0.2. Real dependents resolve it.
+# `major_version_zero` does not stop applying once you pass 1.0 -- it pins the major
+# FOREVER, and it does so by silently demoting breaking changes to MINOR bumps.
+# Measured on a fixture at version 1.2.10:
+#
+#     BREAKING, major_version_zero = true   ->  bump: 1.2.10 -> 1.3.0   (MINOR)
+#     BREAKING, major_version_zero absent   ->  bump: 1.2.10 -> 2.0.0   (MAJOR)
+#
+# A dependent on `unsloth-rs = "1.0"` accepts anything `>=1.0.0, <2.0.0`.
+# Shipping a breaking change as a minor bump therefore lands it silently in every
+# consumer's next build -- a semver violation against a published artifact that cannot be
+# unpublished, only yanked.
+#
+# At 1.x, MAJOR is the breaking position again -- and a major bump still requires explicit
+# human authorization. No agent may cut 2.0.0 any more than it may cut 1.0.0.
+# ============================================================================
+#
+# `version` below is the version cz bumps *from*. It must track the newest released tag:
+# if it lags, `cz bump` re-mints a version that already has a tag.
+
+[tool.commitizen]
+name = "cz_conventional_commits"
+version = "1.0.3"
+tag_format = "v$version"
+version_scheme = "semver"
+
+# Keep these files lockstep on every release bump (see docs/VERSIONING.md § Version files).
+version_files = [
+    "Cargo.toml:version",
+    "README.md:Version:",
+]
+
+update_changelog_on_bump = true
+changelog_file = "CHANGELOG.md"
+changelog_incremental = true

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ CUDA (optional; requires toolkit + device — see [GPU_SETUP.md](GPU_SETUP.md)):
 
 ```toml
 [dependencies]
-unsloth-rs = { version = "1.0.3", features = ["cuda"] }
+unsloth-rs = { version = "1.0", features = ["cuda"] }
 ```
 
 On hosts where the default compute capability pin fails `nvcc` (e.g. CC 12.0

--- a/docs/VERSIONING.md
+++ b/docs/VERSIONING.md
@@ -1,0 +1,97 @@
+# Versioning and releases
+
+## Current version
+
+**`1.0.3`** — tagged `v1.0.3`.
+
+`unsloth-rs` is **published on crates.io**, which makes it one of a small number of repos in this
+fleet whose 1.x is real rather than aspirational. That fact drives every rule below.
+
+## This repo does **not** use `major_version_zero` — and must not
+
+The fleet convention is `major_version_zero = true` in every `.cz.toml`, because nearly every
+repo in the fleet is 0.x and that key is what keeps it there. **This repo is an exception.**
+
+`major_version_zero` does not stop applying once a project passes 1.0. It pins the major
+*permanently*, and it does so by demoting breaking changes to MINOR bumps. Measured on a fixture
+at version 1.2.10:
+
+```
+BREAKING, major_version_zero = true   ->  bump: 1.2.10 -> 1.3.0   (MINOR)
+BREAKING, major_version_zero absent   ->  bump: 1.2.10 -> 2.0.0   (MAJOR)
+```
+
+A dependent on `unsloth-rs = "1.0"` accepts anything `>=1.0.0, <2.0.0`. Shipping a
+breaking change as a minor bump would land it **silently in every consumer's next build** — a
+semver violation against a published artifact that cannot be unpublished, only yanked.
+
+So: do not add that key here. `.cz.toml` carries the same warning inline.
+
+## At 1.x, MAJOR is the breaking position
+
+| Change                        | Bump      | Example |
+| ----------------------------- | --------- | ------- |
+| `fix:`                        | PATCH     | 1.0.3 → 1.0.4 |
+| `feat:`                       | MINOR     | 1.0.3 → 1.1.0 |
+| `feat!:` / `BREAKING CHANGE:` | **MAJOR** | 1.0.3 → **2.0.0** |
+
+This is ordinary semver, and it is the *opposite* of the 0.x repos in this fleet, where the major
+is pinned and MINOR carries breaking changes. If you move between repos here, check which regime
+you are in before reasoning about a bump.
+
+Consumers pin the **major**: `unsloth-rs = "1.0"` tracks every compatible release up to but
+excluding `2.0.0`. Pinning an exact patch (`"1.0.3"`) in a dependency example is a mistake —
+it freezes consumers out of compatible fixes.
+
+### A major bump still needs a human
+
+`cz bump` will happily compute `2.0.0` from a `feat!:` commit. **No agent may cut or propose a
+2.0.0 release**, exactly as no agent may cut a 1.0.0 elsewhere in the fleet. A major bump against
+a published package breaks every dependent by design; that is a maintainer decision, made
+deliberately, with a migration note.
+
+## Version files
+
+[`.cz.toml`](../.cz.toml) lists every place the version appears under `version_files`, so
+`cz bump` moves them together and they cannot drift:
+
+- `Cargo.toml`
+- `README.md`
+- `.cz.toml` itself — `version`
+
+Do not hand-edit any of these — run the tool:
+
+```bash
+cz bump --yes --dry-run     # show what would happen, change nothing
+cz bump                     # move every version file + create the tag
+cz version --project        # what this project currently claims to be
+```
+
+The `version` key in `.cz.toml` is the version cz bumps *from*, so it must track the newest
+released tag. If it lags behind the tag list, the next `cz bump` re-mints a version that already
+has a tag.
+
+## Publication status — the repo is ahead of the registry
+
+**A GitHub Release is not a registry publication.** A git tag with notes publishes nothing
+consumable; only a crates.io upload produces an artifact a dependent can resolve. For this
+project the two currently **disagree**:
+
+| | Version |
+| --- | --- |
+| `Cargo.toml` in this repo | `1.0.3` |
+| Newest git tag | `v1.0.3` |
+| **crates.io `unsloth-rs`** | **`1.0.2`** |
+
+`1.0.3` is tagged but **has never been published to crates.io**. Anyone reading the tag list
+would reasonably conclude it shipped. It did not — `cargo add unsloth-rs` still resolves `1.0.2`.
+When you claim a version is released, say *where*.
+
+## Release steps
+
+1. Land work on `dev` via a work branch — never straight to `main`.
+2. `cz bump` on the release branch: this moves every version file and creates the tag locally.
+3. Open the release PR `dev` → `main`. Merge with a **merge commit**, never a squash.
+4. Push the tag; build the GitHub Release.
+5. **Publishing to crates.io is a separate, deliberate step.** It is not automatic, and until it
+   runs, the version is not released to consumers.


### PR DESCRIPTION
> **Grandfathered repo — the version number is deliberately untouched.** `unsloth-rs` is published
> on crates.io, so renumbering is not possible (you can yank, not unpublish) and would break real
> dependents. This PR fixes **config and docs only**.

## What this fixes

| Source | Said |
| --- | --- |
| `Cargo.toml` (`dev` and `main`) | `1.0.3` |
| `README.md` — *"**Version:** `1.0.3`"* | `1.0.3` |
| Newest git tag | `v1.0.3` |
| **crates.io `unsloth-rs`** | **`1.0.2`** — `1.0.3` was never published |
| **`.cz.toml`** | **did not exist** |
| `README.md` install example | `unsloth-rs = { version = "1.0.3" }` — exact-patch pin |

This is one of the tidier repos — the numbers agree — but nothing was enforcing that, and the
install example pinned an exact patch.

## The important finding: `major_version_zero` must **not** be set here

The fleet standard puts `major_version_zero = true` in every `.cz.toml`. **Applying it to this
repo would be actively harmful, and I did not.**

That key does not stop applying once a project passes 1.0. It pins the major *permanently* by
demoting breaking changes to MINOR bumps. Measured on a fixture at 1.2.10:

```
BREAKING, major_version_zero = true   ->  bump: 1.2.10 -> 1.3.0   (MINOR)
BREAKING, major_version_zero absent   ->  bump: 1.2.10 -> 2.0.0   (MAJOR)
```

A cargo dependent on `unsloth-rs = "1.0"` accepts `>=1.0.0, <2.0.0`. Shipping a breaking change as
`1.1.0` would land it **silently in every consumer's next build** — a semver violation against a
crates.io artifact that cannot be unpublished, only yanked.

Recorded in both `.cz.toml` and `docs/VERSIONING.md` so a later fleet-wide sweep enforcing
"`major_version_zero` everywhere" does not quietly re-introduce it. **This applies to every
grandfathered 1.x repo in the fleet.**

## Verification (real tool output, on this branch)

```
$ cz version --project
1.0.3

$ cargo metadata --no-deps --format-version 1 | jq -r '.packages[]|"\(.name) \(.version)"'
unsloth-rs 1.0.3
```

**The `version_files` list was verified with a real `cz bump`, not a dry run** — on a throwaway
commit, since discarded:

```
$ git commit --allow-empty -m "feat!: p

BREAKING CHANGE: v"
$ cz bump --yes
Cargo.toml -> version = "2.0.0"
README.md  -> **Version:** `2.0.0`
.cz.toml   -> version = "2.0.0"
```

All three moved together, and the breaking change resolved to **MAJOR** (2.0.0) — correct at 1.x,
and the opposite of the 0.x repos in this fleet. The bump and its local tag were then discarded.

## Changes

- **`.cz.toml`** (new) — reference shape **minus `major_version_zero`**, with the reason inline.
  `version_files` covers `Cargo.toml` **and** the README's `**Version:**` status line.
- **`docs/VERSIONING.md`** (new) — current version, why `major_version_zero` is absent, the 1.x
  bump table, **"no agent may cut 2.0.0"**, the version-file list, and the repo-ahead-of-registry
  gap.
- **`README.md`** — the install example pinned `version = "1.0.3"`. Under 1.x the correct moving
  pin is `"1.0"`; an exact-patch pin freezes consumers out of compatible fixes. Note the README's
  own status line already says *"Semver 1.x means the public CPU kernel APIs are intended to be
  usable"* — the example now matches that intent.

## Auto-bumper scan

**None found.** No `semantic-release`, `release-please`, `bumpversion`, or `cz bump` invocation in
`.github/` or any manifest. Nothing here will undo this fix.

## Recommendations for the operator (no action taken)

I did **not** create, move, or delete any tag, and did **not** change any version number.

1. **`v1.0.3` is tagged but never reached crates.io** (which serves `1.0.2`). Either publish, or
   annotate that GitHub Release as source-only.
2. **Do not let a fleet-wide "`major_version_zero` everywhere" sweep touch this repo** or the other
   grandfathered 1.x crates.
