### PR TITLE
feat(rmsnorm): implement vram_estimate for offline planning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Added public `vram_estimate` method to `RmsNorm` for offline planning and memory tracking.
+
 ### Documentation
 - Added `docs/DEPENDENCIES.md` (foundation kernels; no peft/qlora/axolotl deps; no cycles).
 - README docs index: CHANGELOG, ROADMAP, DEBT, GPU_SETUP, PUBLISHING, DEPENDENCIES.

--- a/src/kernels/rmsnorm.rs
+++ b/src/kernels/rmsnorm.rs
@@ -74,6 +74,14 @@ impl RmsNorm {
         }
     }
 
+    /// Estimate VRAM usage in bytes.
+    #[must_use]
+    pub fn vram_estimate(&self, batch_size: usize, seq_len: usize) -> usize {
+        let hidden_size = self.weight.dim(0).unwrap_or(0);
+        let bytes_per_elem = 4; // f32
+        batch_size * seq_len * hidden_size * bytes_per_elem
+    }
+
     /// CPU implementation using Candle tensor operations.
     ///
     /// This is the fallback path and also used for validation.
@@ -213,5 +221,13 @@ mod tests {
             assert!(!v.is_nan(), "Output contains NaN");
             assert!(!v.is_infinite(), "Output contains Inf");
         }
+    }
+
+    #[test]
+    fn test_rmsnorm_vram_estimate() {
+        let device = Device::Cpu;
+        let norm = RmsNorm::new(768, 1e-5, &device).unwrap();
+        let vram = norm.vram_estimate(4, 2048);
+        assert_eq!(vram, 4 * 2048 * 768 * 4);
     }
 }


### PR DESCRIPTION
This PR introduces a comprehensive maintenance and quality improvement by implementing the public `vram_estimate(batch_size, seq_len)` method for the `RmsNorm` struct, ensuring alignment with other core activation layers (such as SwiGLU). A unit test is added to verify the calculation, and CHANGELOG.md is updated to track this improvement.

---
*PR created automatically by Jules for task [1127632926065444921](https://jules.google.com/task/1127632926065444921) started by @tzervas*