### PR TITLE
docs: fix all rustdoc intra-doc link errors on dev

### DIFF
--- a/src/kernels/cubecl/interop.rs
+++ b/src/kernels/cubecl/interop.rs
@@ -320,7 +320,7 @@ pub fn ternary_tensor_to_cubecl_handles(
 /// * `bytes` - Raw bytes from `CubeCL` buffer
 ///
 /// # Returns
-/// Vec<u32> plane data
+/// `Vec<u32>` plane data
 #[must_use]
 pub fn cubecl_bytes_to_u32_plane(bytes: &[u8]) -> Vec<u32> {
     bytes

--- a/src/kernels/cubecl/mod.rs
+++ b/src/kernels/cubecl/mod.rs
@@ -30,7 +30,7 @@
 //!
 //! ## Implementation Status
 //!
-//! See [`FLASH_ATTENTION_IMPLEMENTATION_STATUS.md`] for current progress.
+//! See `FLASH_ATTENTION_IMPLEMENTATION_STATUS.md` for current progress.
 
 pub mod config;
 pub mod interop;

--- a/src/kernels/fused_rmsnorm_rope.rs
+++ b/src/kernels/fused_rmsnorm_rope.rs
@@ -337,7 +337,7 @@ fn rope_kernel<F: Float + CubeElement>(
 ///
 /// # Arguments
 /// * `input` - Input tensor [..., hidden_dim]
-/// * `weight` - Normalization weights [hidden_dim]
+/// * `weight` - Normalization weights `[hidden_dim]`
 /// * `eps` - Epsilon for numerical stability
 ///
 /// # Returns
@@ -382,7 +382,7 @@ pub fn rmsnorm(input: &Tensor, weight: &Tensor, eps: f64) -> UnslothResult<Tenso
 ///
 /// # Arguments
 /// * `input` - Input tensor [batch, seq_len, hidden_dim]
-/// * `weight` - RMSNorm weights [hidden_dim]
+/// * `weight` - RMSNorm weights `[hidden_dim]`
 /// * `cos_cache` - Precomputed cosine values [max_seq, head_dim/2]
 /// * `sin_cache` - Precomputed sine values [max_seq, head_dim/2]
 /// * `head_dim` - Dimension per attention head

--- a/src/kernels/mod.rs
+++ b/src/kernels/mod.rs
@@ -7,7 +7,7 @@
 //!
 //! ## Core Operations
 //! - [`cubecl`] - Flash Attention with online softmax (O(N) memory)
-//! - [`fused_rmsnorm_rope`] - Fused RMSNorm + Rotary Position Embedding
+//! - [`mod@fused_rmsnorm_rope`] - Fused RMSNorm + Rotary Position Embedding
 //! - [`fused_swiglu`] - Fused SwiGLU activation for FFN blocks
 //!
 //! ## Legacy Operations (Candle-based)

--- a/src/kernels/ternary/config.rs
+++ b/src/kernels/ternary/config.rs
@@ -53,7 +53,7 @@ pub struct TernaryConfig {
     pub quantization_threshold: Option<f32>,
 
     /// Scale calibration method for quantization.
-    /// See [`CalibrationMethod`] for options.
+    /// See [`crate::kernels::ternary::CalibrationMethod`] for options.
     pub calibration_method: CalibrationMethodConfig,
 }
 

--- a/src/kernels/ternary/linear.rs
+++ b/src/kernels/ternary/linear.rs
@@ -34,7 +34,7 @@ use candle_core::{Module, Tensor};
 /// # Memory Layout
 ///
 /// - Weights: `TernaryTensor` with +plane/-plane u32 arrays + f32 scales
-/// - Bias: Optional f32 tensor [`out_features`]
+/// - Bias: Optional f32 tensor `[out_features]`
 ///
 /// # Forward Pass
 ///
@@ -47,7 +47,7 @@ pub struct TernaryLinear {
     /// Ternary quantized weight matrix [`out_features`, `in_features`].
     weights: TernaryTensor,
 
-    /// Optional bias vector [`out_features`].
+    /// Optional bias vector `[out_features]`.
     bias: Option<Tensor>,
 
     /// Configuration for ternary operations.
@@ -60,7 +60,7 @@ impl TernaryLinear {
     /// # Arguments
     ///
     /// * `weights` - Pre-quantized ternary weights
-    /// * `bias` - Optional bias tensor [`out_features`]
+    /// * `bias` - Optional bias tensor `[out_features]`
     ///
     /// # Errors
     ///
@@ -74,7 +74,7 @@ impl TernaryLinear {
     /// # Arguments
     ///
     /// * `weights` - Pre-quantized ternary weights
-    /// * `bias` - Optional bias tensor [`out_features`]
+    /// * `bias` - Optional bias tensor `[out_features]`
     /// * `config` - Ternary configuration
     ///
     /// # Errors
@@ -234,7 +234,7 @@ impl TernaryLinearBuilder {
     /// # Arguments
     ///
     /// * `weights` - FP32 weight tensor [`out_features`, `in_features`]
-    /// * `bias` - Optional bias tensor [`out_features`]
+    /// * `bias` - Optional bias tensor `[out_features]`
     ///
     /// # Errors
     ///

--- a/src/kernels/ternary/model.rs
+++ b/src/kernels/ternary/model.rs
@@ -117,7 +117,7 @@ impl Default for ModelQuantizationConfig {
 /// # Arguments
 ///
 /// * `weight` - Weight tensor [`out_features`, `in_features`]
-/// * `bias` - Optional bias tensor [`out_features`]
+/// * `bias` - Optional bias tensor `[out_features]`
 /// * `name` - Layer name for logging
 /// * `config` - Quantization configuration
 /// * `_device` - Target device (currently unused; weights remain on their original device).

--- a/src/kernels/ternary/types.rs
+++ b/src/kernels/ternary/types.rs
@@ -311,7 +311,7 @@ impl TernaryTensor {
     ///
     /// * `plus_plane` - Flattened [rows × `k_words`] positive plane
     /// * `minus_plane` - Flattened [rows × `k_words`] negative plane
-    /// * `scales` - Per-row scale factors [rows]
+    /// * `scales` - Per-row scale factors `[rows]`
     /// * `shape` - Original (`out_features`, `in_features`)
     ///
     /// # Panics

--- a/src/training.rs
+++ b/src/training.rs
@@ -7,14 +7,14 @@
 //! - Mixed precision **dtype helpers** (FP32, FP16, BF16 convert/scale)
 //!   Note: CubeCL interop/kernels remain **f32-only** (`interop_f32_only`).
 //! - Gradient scaling for numerical stability
-//! - Optional [`CheckpointConfig`](crate::memory::CheckpointConfig) for **memory estimates**
+//! - Optional [`CheckpointConfig`] for **memory estimates**
 //!
 //! ## What this is not
 //!
 //! - Not an Unsloth-style gradient-checkpointed training loop.
 //! - Not a public “recompute activations” API. Activation checkpointing recompute
 //!   is intentionally **out of scope** until wired through Candle autograd; use
-//!   [`CheckpointConfig`](crate::memory::CheckpointConfig) only for planning math.
+//!   [`CheckpointConfig`] only for planning math.
 
 use candle_core::{DType, Tensor};
 


### PR DESCRIPTION
The Documentation check runs `RUSTDOCFLAGS="-D warnings"`, so every one of these fails the build the moment the self-hosted runner pool unclogs. Found while sweeping PR #68 — **scope turned out to be 12 errors, not the single ambiguous link first spotted.**

| File | Problem |
|---|---|
| `kernels/mod.rs` | `` [`fused_rmsnorm_rope`] `` is ambiguous — a module **and** a re-exported fn of the same name → `mod@` |
| `training.rs` ×2 | redundant explicit link targets (label already resolves to the same destination) |
| `cubecl/mod.rs` | a **markdown filename** inside link brackets → code span |
| `cubecl/interop.rs` | bare `Vec<u32>` parsed as an unclosed HTML tag → code span |
| `ternary/config.rs` | `CalibrationMethod` not in scope at that site → full path |
| 6 files | tensor-shape prose (`[hidden_dim]`, `[out_features]`, `[rows]`) read as intra-doc links → code spans |

All pre-existing on `dev`; none introduced by PR #68. Docs-only, no API or behavior change.

**Verified locally:** `cargo doc --no-deps` with `-D warnings` builds clean (was 12 errors); `cargo fmt --all -- --check` passes; `cargo clippy --all-targets -- -D warnings` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FLVxZw2PwoF4NwomJLr4fV

---
_Generated by [Claude Code](https://claude.ai/code/session_01FLVxZw2PwoF4NwomJLr4fV)_